### PR TITLE
support Window command prompt

### DIFF
--- a/cmd/jp/main.go
+++ b/cmd/jp/main.go
@@ -7,7 +7,9 @@ import (
 	"log"
 	"os"
 	"reflect"
+	"runtime"
 
+	"github.com/mattn/go-runewidth"
 	"github.com/sgreben/jp/pkg/jp/primitives"
 	"github.com/sgreben/jp/pkg/terminal"
 
@@ -71,9 +73,19 @@ func init() {
 	}
 	if config.Box.Width == 0 {
 		config.Box.Width = terminal.Width()
+		if runtime.GOOS == "windows" {
+			config.Box.Width--
+		}
 	}
 	if config.Box.Height == 0 {
 		config.Box.Height = terminal.Height() - 1
+	}
+	if runewidth.StringWidth(primitives.HorizontalLine) == 2 {
+		primitives.HorizontalLine = "-"
+		primitives.VerticalLine = "|"
+		primitives.CornerBottomLeft = "+"
+		primitives.PointSymbolDefault = "*"
+		primitives.Cross = "X"
 	}
 }
 


### PR DESCRIPTION
![2d7c214c47290e7f](https://user-images.githubusercontent.com/10111/37813418-60b85b3e-2ea8-11e8-94b1-a2b0cb98142f.png)

* Width should be lesser 1 columns on Windows command prompt since output on maximum column make empty line in next line.
* In several country, width of border letter return 2.